### PR TITLE
✨ [feat] #7 일정 상세 조회하기

### DIFF
--- a/src/main/java/com/example/scheduleapp/common/response/enums/ErrorCode.java
+++ b/src/main/java/com/example/scheduleapp/common/response/enums/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     BAD_REQUEST(400, HttpStatus.BAD_REQUEST, "유효한 요청이 아닙니다."),
     MISSING_REQUIRED_HEADER(400, HttpStatus.BAD_REQUEST, "필수 헤더가 누락되었습니다."),
     MISSING_REQUIRED_PARAMETER(400, HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
+    INVALID_PASSWORD(400, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     //404 Not Found
     NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 API입니다."),
     SCHEDULE_NOT_FOUND(404, HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다."),

--- a/src/main/java/com/example/scheduleapp/common/response/enums/SuccessCode.java
+++ b/src/main/java/com/example/scheduleapp/common/response/enums/SuccessCode.java
@@ -13,7 +13,9 @@ public enum SuccessCode {
 
     // 200 OK
     SCHEDULE_GET_SUCCESS(200, HttpStatus.OK, "일정을 성공적으로 찾았습니다."),
-    SCHEDULE_LIST_FOUND(200, HttpStatus.OK, "일정 목록을 성공적으로 찾았습니다");
+    SCHEDULE_LIST_FOUND(200, HttpStatus.OK, "일정 목록을 성공적으로 찾았습니다"),
+    SCHEDULE_PUT_SUCCESS(200, HttpStatus.OK, "일정을 성공적으로 수정했습니다."),
+    SCHEDULE_DELETE_SUCCESS(200, HttpStatus.OK, "일정을 성공적으로 삭제했습니다.");
 
     private final int code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/scheduleapp/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduleapp/schedule/controller/ScheduleController.java
@@ -3,6 +3,7 @@ package com.example.scheduleapp.schedule.controller;
 import com.example.scheduleapp.common.response.ApiResponseDto;
 import com.example.scheduleapp.common.response.enums.SuccessCode;
 import com.example.scheduleapp.schedule.dto.request.ScheduleCreateDto;
+import com.example.scheduleapp.schedule.dto.request.ScheduleUpdateDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDetailDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleListDto;
 import com.example.scheduleapp.schedule.service.ScheduleService;
@@ -37,7 +38,15 @@ public class ScheduleController {
     }
 
     @GetMapping("/{scheduleId}")
-    public ResponseEntity<ApiResponseDto<ScheduleDetailDto>> getDetailSchedules(@PathVariable long scheduleId) {
+    public ResponseEntity<ApiResponseDto<ScheduleDetailDto>> getDetailSchedule(@PathVariable long scheduleId) {
         return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_GET_SUCCESS, scheduleService.getDetailSchedule(scheduleId)));
+    }
+
+    @PutMapping("/{scheduleId}")
+    public  ResponseEntity<ApiResponseDto<ScheduleDetailDto>> getEditSchedule(
+            @PathVariable long scheduleId,
+            @RequestBody ScheduleUpdateDto scheduleUpdateDto
+            ) {
+        return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_PUT_SUCCESS, scheduleService.updateSchedule(scheduleId, scheduleUpdateDto)));
     }
 }

--- a/src/main/java/com/example/scheduleapp/schedule/dto/request/ScheduleUpdateDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/request/ScheduleUpdateDto.java
@@ -1,0 +1,8 @@
+package com.example.scheduleapp.schedule.dto.request;
+
+public record ScheduleUpdateDto(
+        String userName,
+        String todo,
+        String password
+) {
+}

--- a/src/main/java/com/example/scheduleapp/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/scheduleapp/schedule/entity/Schedule.java
@@ -27,4 +27,10 @@ public class Schedule {
         this.password = password;
     }
 
+    public void update(String todo, String userName, Long userId, LocalDateTime updatedAt) {
+        this.todo = todo;
+        this.userName = userName;
+        this.userId = userId;
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/com/example/scheduleapp/schedule/repository/JdbcTemplateScheduleRepository.java
+++ b/src/main/java/com/example/scheduleapp/schedule/repository/JdbcTemplateScheduleRepository.java
@@ -113,6 +113,12 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
         );
     }
 
+    /**
+     * 일정 상세 조회
+     * - scheduleId를 기준으로 일정 1건의 상세 정보를 조회
+     * - 작성자 이름, 할일, 비밀번호, 생성일, 수정일을 포함
+     * - 존재하지 않는 ID일 경우 예외를 발생
+     */
     @Override
     public ScheduleDetailDto getDetailSchedule(long scheduleId) {
         StringBuilder sql = new StringBuilder("""
@@ -141,7 +147,14 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
         }
     }
 
-
+    /**
+     * 일정 정보 수정
+     * - 일정의 user_id, 할 일(todo), 수정일(updated_at)을 수정
+     * - 수정 대상이 존재하지 않으면 예외를 발생
+     *
+     * @param schedule 수정 대상 일정 정보 객체
+     * @return 수정된 일정 정보 (ScheduleDto)
+     */
     @Override
     public ScheduleDto updateSchedule(Schedule schedule) {
         String sql = """
@@ -158,10 +171,12 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
                 schedule.getId()
         );
 
+        // update 쿼리 실행 결과가 0이면 존재하지 않는 ID로 간주하여 예외 처리
         if (updated == 0) {
             throw new BadRequestException(ErrorCode.SCHEDULE_NOT_FOUND);
         }
 
+        // 수정 후 정보 반환
         return new ScheduleDto(
                 schedule.getId(),
                 schedule.getUserId(),
@@ -173,6 +188,14 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
         );
     }
 
+    /**
+     * 일정 ID로 일정 객체 조회
+     * - Schedule 엔티티 전체를 반환 (작성자 ID 및 이름 포함)
+     * - 결과가 없을 경우 예외 처리
+     *
+     * @param scheduleId 조회할 일정 ID
+     * @return 일정 객체
+     */
     @Override
     public Schedule findById(Long scheduleId) {
         String sql = """
@@ -197,6 +220,13 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
         }
     }
 
+    /**
+     * 사용자 이름으로 사용자 ID 조회
+     * - 사용자 이름이 중복되지 않는다는 전제가 필요
+     * - 존재하지 않는 경우 예외 처리
+     * @param userName 사용자 이름
+     * @return 사용자 고유 ID
+     */
     @Override
     public Long findUserIdByName(String userName) {
         try {

--- a/src/main/java/com/example/scheduleapp/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/scheduleapp/schedule/repository/ScheduleRepository.java
@@ -10,13 +10,13 @@ import java.util.List;
 
 public interface ScheduleRepository {
 
-    ScheduleDto createSchedule(Schedule schedule);
+    ScheduleDto createSchedule(Schedule schedule); // 일정 생성
 
-    List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt);
+    List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt); // 일정 전체 조회
 
-    ScheduleDetailDto getDetailSchedule(long scheduleId);
+    ScheduleDetailDto getDetailSchedule(long scheduleId); // 일정 상세 조회
 
-    ScheduleDto updateSchedule(Schedule schedule);
+    ScheduleDto updateSchedule(Schedule schedule); // 일정 수정
 
     Schedule findById(Long scheduleId); // 일정 ID로 조회
 

--- a/src/main/java/com/example/scheduleapp/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/scheduleapp/schedule/repository/ScheduleRepository.java
@@ -15,4 +15,10 @@ public interface ScheduleRepository {
     List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt);
 
     ScheduleDetailDto getDetailSchedule(long scheduleId);
+
+    ScheduleDto updateSchedule(Schedule schedule);
+
+    Schedule findById(Long scheduleId); // 일정 ID로 조회
+
+    Long findUserIdByName(String userName); // 작성자 이름으로 사용자 ID 조회
 }

--- a/src/main/java/com/example/scheduleapp/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduleapp/schedule/service/ScheduleService.java
@@ -1,6 +1,7 @@
 package com.example.scheduleapp.schedule.service;
 
 import com.example.scheduleapp.schedule.dto.request.ScheduleCreateDto;
+import com.example.scheduleapp.schedule.dto.request.ScheduleUpdateDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDetailDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleListDto;
@@ -10,12 +11,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleService {
-    // 메모 생성
-    ScheduleDto createSchedule(ScheduleCreateDto scheduleCreateDto);
 
-    // 메모 전체 조회
-    List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt);
+    ScheduleDto createSchedule(ScheduleCreateDto scheduleCreateDto); // 메모 생성
 
-    // 메모 상세 조회
-    ScheduleDetailDto getDetailSchedule(long scheduleId);
+    List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt); // 메모 전체 조회
+
+    ScheduleDetailDto getDetailSchedule(long scheduleId); // 메모 상세 조회
+
+    ScheduleDetailDto updateSchedule(long scheduleId, ScheduleUpdateDto scheduleUpdateDto); // 메모 수정
 }

--- a/src/main/java/com/example/scheduleapp/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduleapp/schedule/service/ScheduleServiceImpl.java
@@ -1,6 +1,9 @@
 package com.example.scheduleapp.schedule.service;
 
+import com.example.scheduleapp.common.exception.BadRequestException;
+import com.example.scheduleapp.common.response.enums.ErrorCode;
 import com.example.scheduleapp.schedule.dto.request.ScheduleCreateDto;
+import com.example.scheduleapp.schedule.dto.request.ScheduleUpdateDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDetailDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleListDto;
@@ -12,10 +15,10 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
-public class ScheduleServiceImpl implements ScheduleService{
+public class ScheduleServiceImpl implements ScheduleService {
     private final ScheduleRepository scheduleRepository;
 
-    public ScheduleServiceImpl(ScheduleRepository scheduleRepository){
+    public ScheduleServiceImpl(ScheduleRepository scheduleRepository) {
         this.scheduleRepository = scheduleRepository;
     }
 
@@ -40,4 +43,29 @@ public class ScheduleServiceImpl implements ScheduleService{
     public ScheduleDetailDto getDetailSchedule(long scheduleId) {
         return scheduleRepository.getDetailSchedule(scheduleId);
     }
+
+    @Override
+    public ScheduleDetailDto updateSchedule(long scheduleId, ScheduleUpdateDto scheduleUpdateDto) {
+        Schedule schedule = scheduleRepository.findById(scheduleId);
+
+        // 비밀번호가 일치하지 않는 경우, 커스텀 예외 반환
+        if (!schedule.getPassword().equals(scheduleUpdateDto.password())) {
+            throw new BadRequestException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // 새 작성자명으로 사용자 ID 재조회
+        Long userId = scheduleRepository.findUserIdByName(scheduleUpdateDto.userName());
+
+        schedule.update(
+                scheduleUpdateDto.todo(),
+                scheduleUpdateDto.userName(),
+                userId,
+                LocalDateTime.now()
+        );
+
+        scheduleRepository.updateSchedule(schedule); // DB 반영
+
+        return scheduleRepository.getDetailSchedule(scheduleId); // 상세 정보 반환
+    }
+
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 [feat] #7 일정 상세 조회하기

---

### Lv 2. 일정 수정 및 삭제  `필수`

- [ ]  **선택한 일정 수정**
    - [ ]  선택한 일정 내용 중 `할일`, `작성자명` 만 수정 가능
        - [ ]  서버에 일정 수정을 요청할 때 `비밀번호`를 함께 전달합니다.
        - [ ]  `작성일` 은 변경할 수 없으며, `수정일` 은 수정 완료 시, 수정한 시점으로 변경합니다.

### Lv 5. 예외 발생 처리  `도전`

- [ ]  설명
    - [ ]  예외 상황에 대한 처리를 위해 [`[HTTP 상태 코드(링크)](https://developer.mozilla.org/ko/docs/Web/HTTP/Status)`](https://developer.mozilla.org/ko/docs/Web/HTTP/Status)와 `에러 메시지`를 포함한 정보를 사용하여 예외를 관리할 수 있습니다.
        1. 필요에 따라 사용자 정의 예외 클래스를 생성하여 예외 처리를 수행할 수 있습니다.
        2. `@ExceptionHandler`를 활용하여 공통 예외 처리를 구현할 수도 있습니다.
        3. 예외가 발생할 경우 적절한 HTTP 상태 코드와 함께 사용자에게 메시지를 전달하여 상황을 관리합니다.

- [ ]  조건
    - [ ]  수정, 삭제 시 요청할 때 보내는 `비밀번호`가 일치하지 않을 때 예외가 발생합니다.
    - [ ]  선택한 일정 정보를 조회할 수 없을 때 예외가 발생합니다.
        1. 잘못된 정보로 조회하려고 할 때 
        2. 이미 삭제된 정보를 조회하려고 할 때

### ☀️ 어떻게 이슈를 해결했나요?

---
 - Repository 계층 : `updateSchedule(Schedule schedule)` 메서드를 사용하여 일정 생성에 이용한 ScheduleDto 를 재활용하여 설계했습니다. 또한 ScheduleDto는 내부에서만 사용하므로 password를 포함하게 했습니다.
- Service 계층 :  `updateSchedule(long scheduleId, ScheduleUpdateDto dto)` 메서드를 사용하고 반환할 때는 상세조회 API 에서 사용한 `ScheduleDetailDto` 를 통해 클라이언트에게 정보를 반환합니다.

수정이 성공적으로 이루어졌을 때 다음과 같이 반환합니다.
![image](https://github.com/user-attachments/assets/0727ffb1-f908-4599-b61b-545b454a6ee5)

비밀번호가 일치하지 않는 경우, 다음과 같이 반환합니다.
![image](https://github.com/user-attachments/assets/8e01eacd-afd2-421b-a704-fd0828f8a5ec)

일정이 존재하지 않는 경우, 다음과 같이 반환합니다.
![image](https://github.com/user-attachments/assets/d65dd3c6-ba0d-4eaa-b886-38c801a33aaa)

이미 등록된 유저의 이름으로 변경할 경우, 다음과 같이 잘 변경됩니다.
![image](https://github.com/user-attachments/assets/88b400ea-88da-4d6c-a7c4-be3b07bfe9df)

그러나, 유저 정보를 따로 관리하면서 (Level 3) 유저가 존재하지 않는 경우에는 다음과 같이 반환합니다.
![image](https://github.com/user-attachments/assets/739b3cf9-044e-4b35-b15e-667898d048b6)

<br/>


### **❓ 궁금한 점**

1. [ 일정이 존재하지 않는 경우] 와 같이 책임이 `Repository`와 관련된 내용을 예외처리 할 경우에는 `JdbcTemplateScheduleRepository` 에서 예외처리 관련 로직을 다루었으나, [ 비밀번호 수정 ]과 같은 경우에는 비지니스 로직이라고 생각해서 `ScheduleServiceImpl` 에 예외처리 로직을 넣었습니다. 혹시 다음과 같은 형식으로 책임을 분리하는 것이 바람직한가요 ?


2. 유저 테이블을 따로 분리해서 관리하고 있는데, 이럴 경우 유저와 관련된 정보는 유저 수정 API 에서 수정하는 형식으로 관리하는 것이 더 좋지 않나요 … ? 하지만 요구사항에 선택한 일정의 작성자명을 수정할 수 있다고 되어 있어서 수정할 수 있도록 구현하긴 했습니다 😊

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
