### PR TITLE
✨ [feat] #11 작성자와 일정 간 연관관계 설정 

### DIFF
--- a/src/main/java/com/example/scheduleapp/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduleapp/schedule/controller/ScheduleController.java
@@ -30,12 +30,13 @@ public class ScheduleController {
         return ApiResponseDto.success(SuccessCode.SCHEDULE_POST_SUCCESS, scheduleService.createSchedule(scheduleCreateDto));
     }
 
+    // 전체 일정 조회 - (작성자의 고유 식별자를 통해 일정이 검색이 될 수 있도록 전체 일정 조회 코드 수정.)
     @GetMapping
     public ResponseEntity<ApiResponseDto<List<ScheduleListDto>>> getAllSchedules(
-            @RequestParam(required = false) String userName,
+            @RequestParam(required = false) Long userId,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime updatedAt
     ) {
-        return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_LIST_FOUND, scheduleService.getAllSchedules(userName, updatedAt)));
+        return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_LIST_FOUND, scheduleService.getAllSchedules(userId, updatedAt)));
     }
 
     @GetMapping("/{scheduleId}")

--- a/src/main/java/com/example/scheduleapp/schedule/dto/request/ScheduleCreateDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/request/ScheduleCreateDto.java
@@ -2,6 +2,7 @@ package com.example.scheduleapp.schedule.dto.request;
 
 public record ScheduleCreateDto(
         String userName,
+        String email,
         String todo,
         String password
 ) {}

--- a/src/main/java/com/example/scheduleapp/schedule/dto/response/ScheduleDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/response/ScheduleDto.java
@@ -5,6 +5,7 @@ public record ScheduleDto(
         Long id,
         Long userId,
         String userName,
+        String email,
         String todo,
         String password,
         LocalDateTime createdAt,

--- a/src/main/java/com/example/scheduleapp/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/scheduleapp/schedule/entity/Schedule.java
@@ -15,14 +15,16 @@ public class Schedule {
     private Long id;
     private Long userId;
     private String userName;
+    private String email;
     private String todo;
     private String password;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     // 생성자
-    public Schedule(String userName, String todo, String password) {
+    public Schedule(String userName, String email, String todo, String password) {
         this.userName = userName;
+        this.email = email;
         this.todo = todo;
         this.password = password;
     }

--- a/src/main/java/com/example/scheduleapp/schedule/repository/JdbcTemplateScheduleRepository.java
+++ b/src/main/java/com/example/scheduleapp/schedule/repository/JdbcTemplateScheduleRepository.java
@@ -88,12 +88,12 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
 
     /**
      * 일정 목록 조회
-     * - userName, updatedAt 두 조건 모두 선택적
+     * - userId, updatedAt 두 조건 모두 선택적
      * - 조건이 존재할 경우 WHERE 절에 추가
      * - updated_at 기준 내림차순 정렬
      */
     @Override
-    public List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt) {
+    public List<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt) {
         StringBuilder sql = new StringBuilder("""
                     SELECT s.id, u.name, s.todo, s.updated_at
                     FROM schedule s
@@ -101,12 +101,12 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
                     WHERE 1=1
                 """);
 
-        List<Object> params = new ArrayList<>(); // 리스트에 파라미터들 담기
+        List<Object> params = new ArrayList<>();
 
-        // 작성자 이름 조건 추가
-        if (userName != null && !userName.isBlank()) {
-            sql.append(" AND u.name = ?");
-            params.add(userName);
+        // userId 조건 추가
+        if (userId != null) {
+            sql.append(" AND s.user_id = ?");
+            params.add(userId);
         }
 
         // 수정일 조건 추가 (날짜만 비교)
@@ -115,10 +115,8 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
             params.add(updatedAt);
         }
 
-        // 수정일 내림차순 정렬
-        sql.append(" ORDER BY s.updated_at DESC");
+        sql.append(" ORDER BY s.updated_at DESC"); // 수정일 내림차순 정렬
 
-        // 쿼리 실행을 ScheduleListDto에 담아서 반환
         return jdbcTemplate.query(sql.toString(), (rs, rowNum) ->
                 new ScheduleListDto(
                         rs.getLong("id"),
@@ -128,6 +126,7 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
                 ), params.toArray()
         );
     }
+
 
     /**
      * 일정 상세 조회
@@ -197,6 +196,7 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
                 schedule.getId(),
                 schedule.getUserId(),
                 schedule.getUserName(),
+                schedule.getEmail(),
                 schedule.getTodo(),
                 schedule.getPassword(),
                 schedule.getCreatedAt(),

--- a/src/main/java/com/example/scheduleapp/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/scheduleapp/schedule/repository/ScheduleRepository.java
@@ -12,7 +12,7 @@ public interface ScheduleRepository {
 
     ScheduleDto createSchedule(Schedule schedule); // 일정 생성
 
-    List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt); // 일정 전체 조회
+    List<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt); // 일정 전체 조회 (userId)
 
     ScheduleDetailDto getDetailSchedule(long scheduleId); // 일정 상세 조회
 

--- a/src/main/java/com/example/scheduleapp/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduleapp/schedule/service/ScheduleService.java
@@ -14,7 +14,7 @@ public interface ScheduleService {
 
     ScheduleDto createSchedule(ScheduleCreateDto scheduleCreateDto); // 메모 생성
 
-    List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt); // 메모 전체 조회
+    List<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt); // 메모 전체 조회 (userId로 조회)
 
     ScheduleDetailDto getDetailSchedule(long scheduleId); // 메모 상세 조회
 

--- a/src/main/java/com/example/scheduleapp/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduleapp/schedule/service/ScheduleServiceImpl.java
@@ -9,11 +9,13 @@ import com.example.scheduleapp.schedule.dto.response.ScheduleDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleListDto;
 import com.example.scheduleapp.schedule.entity.Schedule;
 import com.example.scheduleapp.schedule.repository.ScheduleRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 public class ScheduleServiceImpl implements ScheduleService {
     private final ScheduleRepository scheduleRepository;
@@ -31,6 +33,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     public ScheduleDto createSchedule(ScheduleCreateDto scheduleCreateDto) {
         Schedule schedule = new Schedule(
                 scheduleCreateDto.userName(),
+                scheduleCreateDto.email(),
                 scheduleCreateDto.todo(),
                 scheduleCreateDto.password()
         );
@@ -46,10 +49,20 @@ public class ScheduleServiceImpl implements ScheduleService {
      * @param updatedAt 수정일 기준 (Optional)
      * @return 일정 리스트
      */
+    /**
+     * 일정 목록 조회 메서드
+     * - 사용자 이름과 수정일을 기준으로 일정 목록을 조회
+     * - 조건이 없다면 전체 일정 반환
+     *
+     * @param userName 작성자명 (Optional)
+     * @param updatedAt 수정일 기준 (Optional)
+     * @return 일정 리스트
+     */
     @Override
-    public List<ScheduleListDto> getAllSchedules(String userName, LocalDateTime updatedAt) {
-        return scheduleRepository.getAllSchedules(userName, updatedAt);
+    public List<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt) {
+        return scheduleRepository.getAllSchedules(userId, updatedAt); // userId 기반 조회
     }
+
 
     /**
      * 특정 일정 상세 조회

--- a/src/main/java/com/example/scheduleapp/users/controller/UsersController.java
+++ b/src/main/java/com/example/scheduleapp/users/controller/UsersController.java
@@ -1,0 +1,4 @@
+package com.example.scheduleapp.users.controller;
+
+public class UsersController {
+}

--- a/src/main/java/com/example/scheduleapp/users/entity/Users.java
+++ b/src/main/java/com/example/scheduleapp/users/entity/Users.java
@@ -1,0 +1,18 @@
+package com.example.scheduleapp.users.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Users {
+    private Long id;
+    private String userName;
+    private String email;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/scheduleapp/users/repository/UsersRepository.java
+++ b/src/main/java/com/example/scheduleapp/users/repository/UsersRepository.java
@@ -1,0 +1,4 @@
+package com.example.scheduleapp.users.repository;
+
+public interface UsersRepository {
+}

--- a/src/main/java/com/example/scheduleapp/users/service/UserServiceImpl.java
+++ b/src/main/java/com/example/scheduleapp/users/service/UserServiceImpl.java
@@ -1,0 +1,7 @@
+package com.example.scheduleapp.users.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserServiceImpl {
+}

--- a/src/main/java/com/example/scheduleapp/users/service/UsersService.java
+++ b/src/main/java/com/example/scheduleapp/users/service/UsersService.java
@@ -1,0 +1,4 @@
+package com.example.scheduleapp.users.service;
+
+public interface UsersService {
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 [feat] #11 작성자와 일정 간 연관관계 설정 

---
userId=1 로 조회한 경우, 다음과 같이 보여집니다.
![image](https://github.com/user-attachments/assets/626483a3-4fa2-48c0-a1e6-1b366c388bc7)


### ☀️ 어떻게 이슈를 해결했나요?

---

현재 일정 전체 목록을 조회할 때, 동명이인의 작성자가 있을 경우, 어떤 작성자가 작성한 것인지 구분이 불가능합니다. 따라서 고유 식별자인 userId로 조회하는 방식으로 개선했습니다.


<br/>


### ❄️ 주의할 점

---
동명이인이 User에 등록되어있을 경우, 현재 일정을 생성할 때 다음과 같은 정보만 담기 때문에 일정을 생성하지 못합니다.
```json
{
   "todo" : "운동하기",
  "userName": "예은",
  "password": "1234"
}
```
따라서 일정 생성 시, 포함되어야할 데이터에 이메일을 추가했습니다.
```java
public Long findUserIdByNameAndEmail(String userName, String email) {
        try {
            return jdbcTemplate.queryForObject(
                    "SELECT id FROM users WHERE name = ? AND email = ?",
                    Long.class,
                    userName,
                    email
            );
        } catch (EmptyResultDataAccessException e) {
            throw new BadRequestException(ErrorCode.USER_NOT_FOUND);
        }
    }
```
email과 userName을 기반으로 userId를 조회하여 userId를 통해 일정을 저장하는 형식으로 구현했습니다.


![image](https://github.com/user-attachments/assets/5073862c-156e-4a25-95ea-67d142391051)
