### PR TITLE
✨ [feat] #15 페이지네이션 적용

### DIFF
--- a/src/main/java/com/example/scheduleapp/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduleapp/schedule/controller/ScheduleController.java
@@ -48,7 +48,6 @@ public class ScheduleController {
         ));
     }
 
-
     @GetMapping("/{scheduleId}")
     public ResponseEntity<ApiResponseDto<ScheduleDetailDto>> getDetailSchedule(@PathVariable final long scheduleId) {
         return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_GET_SUCCESS, scheduleService.getDetailSchedule(scheduleId)));
@@ -58,7 +57,7 @@ public class ScheduleController {
     public ResponseEntity<ApiResponseDto<ScheduleDetailDto>> editSchedule(
             @PathVariable final long scheduleId,
             @RequestBody @Valid final ScheduleUpdateDto scheduleUpdateDto
-            ) {
+    ) {
         return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_PUT_SUCCESS, scheduleService.updateSchedule(scheduleId, scheduleUpdateDto)));
     }
 

--- a/src/main/java/com/example/scheduleapp/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/scheduleapp/schedule/controller/ScheduleController.java
@@ -2,9 +2,11 @@ package com.example.scheduleapp.schedule.controller;
 
 import com.example.scheduleapp.common.response.ApiResponseDto;
 import com.example.scheduleapp.common.response.enums.SuccessCode;
+import com.example.scheduleapp.schedule.dto.request.PageRequestDto;
 import com.example.scheduleapp.schedule.dto.request.ScheduleCreateDto;
 import com.example.scheduleapp.schedule.dto.request.ScheduleDeleteDto;
 import com.example.scheduleapp.schedule.dto.request.ScheduleUpdateDto;
+import com.example.scheduleapp.schedule.dto.response.PageResponseDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDetailDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleListDto;
 import com.example.scheduleapp.schedule.service.ScheduleService;
@@ -33,12 +35,19 @@ public class ScheduleController {
 
     // 전체 일정 조회 - (작성자의 고유 식별자를 통해 일정이 검색이 될 수 있도록 전체 일정 조회 코드 수정.)
     @GetMapping
-    public ResponseEntity<ApiResponseDto<List<ScheduleListDto>>> getAllSchedules(
+    public ResponseEntity<ApiResponseDto<PageResponseDto<ScheduleListDto>>> getAllSchedules(
             @RequestParam(required = false) final Long userId,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDateTime updatedAt
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDateTime updatedAt,
+            @RequestParam(defaultValue = "0") int page, // 페이지 번호 (기본값: 0)
+            @RequestParam(defaultValue = "10") int size // 페이지당 일정 개수 (기본값: 10)
     ) {
-        return ResponseEntity.ok(ApiResponseDto.success(SuccessCode.SCHEDULE_LIST_FOUND, scheduleService.getAllSchedules(userId, updatedAt)));
+        PageRequestDto pageRequestDto = new PageRequestDto(page, size);
+        return ResponseEntity.ok(ApiResponseDto.success(
+                SuccessCode.SCHEDULE_LIST_FOUND,
+                scheduleService.getAllSchedules(userId, updatedAt, pageRequestDto)
+        ));
     }
+
 
     @GetMapping("/{scheduleId}")
     public ResponseEntity<ApiResponseDto<ScheduleDetailDto>> getDetailSchedule(@PathVariable final long scheduleId) {

--- a/src/main/java/com/example/scheduleapp/schedule/dto/request/PageRequestDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/request/PageRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.scheduleapp.schedule.dto.request;
+
+public record PageRequestDto(
+        int page,     // 요청한 페이지 번호 (0부터 시작)
+        int size      // 한 페이지에 보여줄 항목 수
+) {
+    // 현재 페이지의 시작 위치(offset)를 계산하는 메서드
+    public int offset() {
+        return page * size;
+    }
+}

--- a/src/main/java/com/example/scheduleapp/schedule/dto/request/ScheduleCreateDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/request/ScheduleCreateDto.java
@@ -1,8 +1,6 @@
 package com.example.scheduleapp.schedule.dto.request;
 
-
 import jakarta.validation.constraints.*;
-
 
 public record ScheduleCreateDto(
         @NotBlank(message = "작성자의 이름을 추가해주세요.")

--- a/src/main/java/com/example/scheduleapp/schedule/dto/response/PageResponseDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/response/PageResponseDto.java
@@ -8,5 +8,4 @@ public record PageResponseDto<T>(
         int size,          // 페이지 크기
         int totalPages,    // 전체 페이지 수
         long totalElements // 전체 데이터 개수
-) {
-}
+) {}

--- a/src/main/java/com/example/scheduleapp/schedule/dto/response/PageResponseDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/response/PageResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.scheduleapp.schedule.dto.response;
+
+import java.util.List;
+
+public record PageResponseDto<T>(
+        List<T> content,   // 실제 데이터 목록
+        int page,          // 현재 페이지
+        int size,          // 페이지 크기
+        int totalPages,    // 전체 페이지 수
+        long totalElements // 전체 데이터 개수
+) {
+}

--- a/src/main/java/com/example/scheduleapp/schedule/dto/response/ScheduleDetailDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/response/ScheduleDetailDto.java
@@ -9,6 +9,4 @@ public record ScheduleDetailDto(
         String password,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
-
-) {
-}
+) {}

--- a/src/main/java/com/example/scheduleapp/schedule/dto/response/ScheduleListDto.java
+++ b/src/main/java/com/example/scheduleapp/schedule/dto/response/ScheduleListDto.java
@@ -8,5 +8,4 @@ public record ScheduleListDto(
         String email,
         String todo,
         LocalDateTime updatedAt
-) {
-}
+) {}

--- a/src/main/java/com/example/scheduleapp/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/scheduleapp/schedule/entity/Schedule.java
@@ -29,6 +29,7 @@ public class Schedule {
         this.password = password;
     }
 
+    // update 메서드
     public void update(String todo, String userName, String email, Long userId, LocalDateTime updatedAt) {
         this.todo = todo;
         this.userName = userName;

--- a/src/main/java/com/example/scheduleapp/schedule/repository/JdbcTemplateScheduleRepository.java
+++ b/src/main/java/com/example/scheduleapp/schedule/repository/JdbcTemplateScheduleRepository.java
@@ -74,6 +74,14 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
         );
     }
 
+    /**
+     * 사용자의 이름(userName)과 이메일(email)을 이용하여 해당 사용자의 ID를 조회하는 메서드.
+     *
+     * @param userName 조회할 사용자의 이름
+     * @param email    조회할 사용자의 이메일
+     * @return         해당 사용자의 ID (Long 타입)
+     * @throws BadRequestException 사용자가 존재하지 않을 경우 예외 발생
+     */
     public Long findUserIdByNameAndEmail(String userName, String email) {
         try {
             return jdbcTemplate.queryForObject(
@@ -161,6 +169,13 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository {
             params.add(userId);
         }
 
+        if (updatedAt != null) {
+            sql.append(" AND DATE(s.updated_at) = DATE(?)");
+            params.add(updatedAt);
+        }
+
+        return jdbcTemplate.queryForObject(sql.toString(), Long.class, params.toArray());
+    }
 
     /**
      * 일정 상세 조회

--- a/src/main/java/com/example/scheduleapp/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/scheduleapp/schedule/repository/ScheduleRepository.java
@@ -1,5 +1,6 @@
 package com.example.scheduleapp.schedule.repository;
 
+import com.example.scheduleapp.schedule.dto.request.PageRequestDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDetailDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleListDto;
@@ -12,7 +13,9 @@ public interface ScheduleRepository {
 
     ScheduleDto createSchedule(Schedule schedule); // 일정 생성
 
-    List<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt); // 일정 전체 조회 (userId)
+    List<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt, PageRequestDto pageRequestDto); // 일정 전체 조회 (userId)
+
+    long countSchedules(Long userId, LocalDateTime updatedAt); // 일정 수 조회
 
     ScheduleDetailDto getDetailSchedule(long scheduleId); // 일정 상세 조회
 

--- a/src/main/java/com/example/scheduleapp/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/scheduleapp/schedule/service/ScheduleService.java
@@ -1,7 +1,9 @@
 package com.example.scheduleapp.schedule.service;
 
+import com.example.scheduleapp.schedule.dto.request.PageRequestDto;
 import com.example.scheduleapp.schedule.dto.request.ScheduleCreateDto;
 import com.example.scheduleapp.schedule.dto.request.ScheduleUpdateDto;
+import com.example.scheduleapp.schedule.dto.response.PageResponseDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDetailDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleListDto;
@@ -14,7 +16,8 @@ public interface ScheduleService {
 
     ScheduleDto createSchedule(ScheduleCreateDto scheduleCreateDto); // 메모 생성
 
-    List<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt); // 메모 전체 조회 (userId로 조회)
+    // 메모 전체 조회 (userId로 조회) + 페이지네이션 적용
+    PageResponseDto<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt, PageRequestDto pageRequestDto);
 
     ScheduleDetailDto getDetailSchedule(long scheduleId); // 메모 상세 조회
 

--- a/src/main/java/com/example/scheduleapp/schedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/scheduleapp/schedule/service/ScheduleServiceImpl.java
@@ -2,8 +2,10 @@ package com.example.scheduleapp.schedule.service;
 
 import com.example.scheduleapp.common.exception.BadRequestException;
 import com.example.scheduleapp.common.response.enums.ErrorCode;
+import com.example.scheduleapp.schedule.dto.request.PageRequestDto;
 import com.example.scheduleapp.schedule.dto.request.ScheduleCreateDto;
 import com.example.scheduleapp.schedule.dto.request.ScheduleUpdateDto;
+import com.example.scheduleapp.schedule.dto.response.PageResponseDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDetailDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleDto;
 import com.example.scheduleapp.schedule.dto.response.ScheduleListDto;
@@ -45,24 +47,33 @@ public class ScheduleServiceImpl implements ScheduleService {
      * - 사용자 이름과 수정일을 기준으로 일정 목록을 조회
      * - 조건이 없다면 전체 일정 반환
      *
-     * @param userName 작성자명 (Optional)
-     * @param updatedAt 수정일 기준 (Optional)
-     * @return 일정 리스트
-     */
-    /**
-     * 일정 목록 조회 메서드
-     * - 사용자 이름과 수정일을 기준으로 일정 목록을 조회
-     * - 조건이 없다면 전체 일정 반환
-     *
      * @param userId 작성자명 (Optional)
      * @param updatedAt 수정일 기준 (Optional)
      * @return 일정 리스트
      */
+    // 일정 목록을 페이지네이션하여 조회하는 메서드
     @Override
-    public List<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt) {
-        return scheduleRepository.getAllSchedules(userId, updatedAt); // userId 기반 조회
-    }
+    public PageResponseDto<ScheduleListDto> getAllSchedules(Long userId, LocalDateTime updatedAt, PageRequestDto pageRequestDto) {
 
+        // 일정 목록 조회 (페이지네이션 적용)
+        List<ScheduleListDto> schedules = scheduleRepository.getAllSchedules(userId, updatedAt, pageRequestDto);
+
+        // 전체 일정 개수 조회
+        long totalCount = scheduleRepository.countSchedules(userId, updatedAt);
+
+        // 전체 페이지 개수 계산 (총 개수 / 한 페이지당 개수) → 올림 처리
+        int totalPages = (int) Math.ceil((double) totalCount / pageRequestDto.size());
+
+        // 페이지네이션 정보를 포함한 응답 DTO 반환
+        return new PageResponseDto<>(
+                schedules,               // 조회된 일정 목록
+                pageRequestDto.page(),   // 현재 페이지 번호
+                pageRequestDto.size(),   // 한 페이지당 데이터 개수
+                totalPages,             // 전체 페이지 개수
+                totalCount            // 전체 일정 개수
+
+        );
+    }
 
     /**
      * 특정 일정 상세 조회


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 [feat] #15 페이지네이션 적용

---
범위를 넘어선 페이지를 요청하는 경우, 빈 배열을 반환합니다.
![image](https://github.com/user-attachments/assets/f3fa9977-01d0-462e-9e1a-266bd755b440)

등록된 일정 목록을 페이지 번호와 크기를 기준으로 모두 조회 가능합니다.
![image](https://github.com/user-attachments/assets/9f381179-0377-4e53-b6cd-f08f3e202f2d)

페이지의 디폴트 값은 page=0 , size=10으로 설정했습니다.
![image](https://github.com/user-attachments/assets/c0ad89a0-902b-4336-ad40-41ba26900141)


### ☀️ 어떻게 이슈를 해결했나요?

---
페이징 처리를 깔끔하고 일관되게 하기 위해 page, size 정보를 `PageRequestDto` 같은 객체로 만들어 사용했습니다.

```java
package com.example.scheduleapp.schedule.dto.request;

public record PageRequestDto(
        int page,     // 요청한 페이지 번호 (0부터 시작)
        int size      // 한 페이지에 보여줄 항목 수
) {
    // 현재 페이지의 시작 위치(offset)를 계산하는 메서드
    public int offset() {
        return page * size;
    }
}
```

